### PR TITLE
Reduce nav-to-intro spacing on mobile by 50%

### DIFF
--- a/style.css
+++ b/style.css
@@ -1876,6 +1876,12 @@ html {
   margin-top: 5rem;
 }
 
+@media (max-width: 599px) {
+  .home.intro {
+    margin-top: 2.5rem;
+  }
+}
+
 .home.books {
   margin-top: 5rem;
 }

--- a/style.scss
+++ b/style.scss
@@ -1646,6 +1646,9 @@ html {
 
 .home.intro {
   margin-top: 5rem;
+  @media (max-width: $screen-sm-max) {
+    margin-top: 2.5rem;
+  }
 }
 
 .home.books {


### PR DESCRIPTION
Add a media query for small screens (max-width: 599px) that cuts the
.home.intro margin-top from 5rem to 2.5rem.

https://claude.ai/code/session_01JypJNBwZZwc4YemJjLHumE